### PR TITLE
fix: cors headers error for endpoint that has query params lang en

### DIFF
--- a/src/app/api/all/route.ts
+++ b/src/app/api/all/route.ts
@@ -1,15 +1,12 @@
 import { corsHeaders } from "@/app/api/cors";
-import { templates, templatesEn } from "@/lib/template";
+import { templates as templatesId, templatesEn } from "@/lib/template";
 import { NextRequest, NextResponse } from "next/server";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(request: NextRequest) {
   const lang = request.nextUrl.searchParams.get("lang");
-
-  if (lang === "en") {
-    return NextResponse.json(templatesEn);
-  }
+  const templates = lang === "en" ? templatesEn : templatesId;
 
   return NextResponse.json(templates, {
     headers: corsHeaders,

--- a/src/app/api/one/route.ts
+++ b/src/app/api/one/route.ts
@@ -1,5 +1,5 @@
 import { corsHeaders } from "@/app/api/cors";
-import { templates, templatesEn } from "@/lib/template";
+import { templates as templatesId, templatesEn } from "@/lib/template";
 import { NextRequest, NextResponse } from "next/server";
 
 export const dynamic = "force-dynamic"; // defaults to auto
@@ -7,13 +7,7 @@ export const dynamic = "force-dynamic"; // defaults to auto
 export async function GET(request: NextRequest) {
   const lang = request.nextUrl.searchParams.get("lang");
 
-  if (lang === "en") {
-    const random = Math.floor(Math.random() * templatesEn.length);
-    const template = templatesEn[random];
-
-    return NextResponse.json(template);
-  }
-
+  const templates = lang === "en" ? templatesEn : templatesId;
   const random = Math.floor(Math.random() * templates.length);
   const template = templates[random];
 


### PR DESCRIPTION
Code repetition causes us to forget to return CORS headers for API endpoints that have query parameters.

In this case, the query parameter for 'lang=en'.

This PR attempts to simplify the logic of the code to fix CORS errors caused by forgetting to return 'corsHeaders'

### before

![Screenshot 2024-03-09 at 16 08 26](https://github.com/zakiego/salin-abangku/assets/46083126/cb838f52-455f-4367-bd90-8027a70aff12)


### after

![Screenshot 2024-03-09 at 16 11 16](https://github.com/zakiego/salin-abangku/assets/46083126/1eb502dd-a590-43ac-acb6-fd587ccbd92a)
